### PR TITLE
Adding the routers initial configurations and the app configurator function

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,16 @@
+/* eslint-disable import/first */
+process.env.NODE_CONFIG_DIR = './src/configs'
 import Express from 'express'
-process.env.NODE_CONFIG_DIR = 'configs'
+import { configure, routers } from './start'
+import configs from './configs'
 
 const app:Express.Application = Express();
 
 (async () => {
-  // other configurations will be set from here:
-
+  // Configure the appliction (Parser, and additonal headers):
+  configure(app)
+  // init the routers:
+  app.use(configs.API_PREFIX, routers)
 })()
 
 export default app

--- a/src/configs/default.sample.json
+++ b/src/configs/default.sample.json
@@ -1,4 +1,5 @@
 {
     "env": "development",
-    "FRONTEND_HOST": ""
+    "FRONTEND_HOST": "",
+    "API_PREFIX": "/"
 }

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -3,11 +3,13 @@ import config from 'config'
 interface configsInterface {
     env: string,
     FRONTEND_HOST: string,
+    API_PREFIX: string
 }
 
 const configs: configsInterface = {
   env: config.get('env'),
-  FRONTEND_HOST: config.get('FRONTEND_HOST')
+  FRONTEND_HOST: config.get('FRONTEND_HOST'),
+  API_PREFIX: config.get('API_PREFIX')
 }
 
 export default configs

--- a/src/start/configurator.ts
+++ b/src/start/configurator.ts
@@ -1,0 +1,22 @@
+/**
+ *
+ * Any needed configurations will be set here:
+ *
+ */
+
+import Express from 'express'
+
+export default (app: Express.Application) => {
+  /**
+        * For Express 4.16.0 and higher: body parser has been re-added to provide request body parsing support out-of-the-box.
+        * If you're using a version less than 4.16.0 use body-parser.
+        */
+  app.use(Express.json())
+
+  // Access-control headers:
+  app.use((req:Express.Request, res:Express.Response, next:Express.NextFunction) => {
+    res.header('Access-Control-Allow-Origin', '*')
+    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+    next()
+  })
+}

--- a/src/start/index.ts
+++ b/src/start/index.ts
@@ -1,0 +1,2 @@
+export { default as configure } from './configurator'
+export { default as routers } from './routers'

--- a/src/start/routers.ts
+++ b/src/start/routers.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express'
+const router = Router()
+
+// Startup Route:
+router.get('/', function (req, res) {
+  res.send('Server running. <br><br> <br>Repo https://github.com/EOS-uiux-Solutions/eos-icons-api')
+})
+
+// Configure Routes:
+
+export default router


### PR DESCRIPTION
### Description

This Pull Request introduces:
1) the Routers configurator, which will be used to setup all other routers (router for each service). 
a folder `routes` will be made later, which will contain the routers, and then they can be setup in the routers file. 
2) App configurator function to setup any needed configs, like the parser, the additional headers and so on. 
