### PR TITLE
Adding Joi to validate the APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "grunt-sass": "^3.1.0",
         "grunt-text-replace": "^0.4.0",
         "grunt-webfont": "^1.7.2",
+        "joi": "^17.4.2",
         "mongoose": "^5.12.13",
         "newman": "^5.2.3",
         "node-cmd": "^4.0.0",
@@ -202,6 +203,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz",
@@ -307,6 +321,24 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -5121,6 +5153,18 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "node_modules/joi": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+      "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-sha512": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
@@ -9337,6 +9381,19 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@mapbox/node-pre-gyp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz",
@@ -9414,6 +9471,24 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -13037,6 +13112,18 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "joi": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+      "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "js-sha512": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "grunt-sass": "^3.1.0",
     "grunt-text-replace": "^0.4.0",
     "grunt-webfont": "^1.7.2",
+    "joi": "^17.4.2",
     "mongoose": "^5.12.13",
     "newman": "^5.2.3",
     "node-cmd": "^4.0.0",

--- a/src/components/icons/controller.icons.ts
+++ b/src/components/icons/controller.icons.ts
@@ -45,8 +45,8 @@ const getIcons = async (req: Express.Request, res: Express.Response, next: Expre
         }
         return icon
       })
-      return respond(200, { icons }, res)
     }
+    return respond(200, { icons }, res)
   } catch (err) {
     IconsLogger.logError('getIcons', err)
     next(err)

--- a/src/components/icons/router.icons.ts
+++ b/src/components/icons/router.icons.ts
@@ -1,13 +1,15 @@
 import express from 'express'
 import * as controller from './controller.icons'
+import { validateSchema } from 'middlewares'
+import * as validationSchemas from './validation.icons'
 const router = express.Router()
 
 const prefix = '/icons'
 router.post('/newReleaseGitlab', controller.newRelease)
-router.post('/getIcons', controller.getIcons)
-router.post('/getString', controller.getString)
-router.post('/getFile', controller.getFile)
-router.post('/getFont', controller.getFont)
+router.post('/getIcons', validateSchema(validationSchemas.getIcons, 'body'), controller.getIcons)
+router.post('/getString', validateSchema(validationSchemas.getString, 'body'), controller.getString)
+router.post('/getFile', validateSchema(validationSchemas.getFile, 'body'), controller.getFile)
+router.post('/getFont', validateSchema(validationSchemas.getFont, 'body'), controller.getFont)
 
 export {
   router,

--- a/src/components/icons/validation.icons.ts
+++ b/src/components/icons/validation.icons.ts
@@ -1,0 +1,46 @@
+import Joi from 'joi'
+
+const customizations = Joi.object({
+  colorCode: Joi.string(),
+  rotateAngle: Joi.number(),
+  flip: Joi.object({
+    horizontal: Joi.boolean(),
+    vertical: Joi.boolean()
+  })
+})
+const theme = Joi.string().valid('outlined', 'filled').required()
+const icons = Joi.array().items(Joi.string()).min(1).required()
+
+/// ////////////////////////////////////
+
+const getIcons = Joi.object({
+  color: Joi.string()
+})
+
+const getString = Joi.object({
+  icons,
+  customizations,
+  theme,
+  stringType: Joi.string().valid('base64', 'svg').required()
+})
+
+const getFont = Joi.object({
+  icons,
+  customizations,
+  theme
+})
+
+const getFile = Joi.object({
+  icons,
+  theme,
+  customizationConfig: customizations,
+  exportAs: Joi.string().valid('svg', 'png').required(),
+  exportSize: Joi.number().required()
+
+})
+export {
+  getIcons,
+  getString,
+  getFont,
+  getFile
+}

--- a/src/components/suggestion/router.suggestion.ts
+++ b/src/components/suggestion/router.suggestion.ts
@@ -1,11 +1,13 @@
 import express from 'express'
 import * as controller from './controller.suggestion'
+import { validateSchema } from 'middlewares'
+import * as validationSchemas from './validation.suggestion'
 const router = express.Router()
 
 const prefix = '/suggestion'
-router.post('/add', controller.addSuggestion)
+router.post('/add', validateSchema(validationSchemas.addSuggestion, 'body'), controller.addSuggestion)
 router.get('/getAll', controller.getAllSuggestions)
-router.post('/decide', controller.decide)
+router.post('/decide', validateSchema(validationSchemas.decide, 'body'), controller.decide)
 
 export {
   router,

--- a/src/components/suggestion/router.suggestion.ts
+++ b/src/components/suggestion/router.suggestion.ts
@@ -1,7 +1,6 @@
 import express from 'express'
-import { isAdmin } from 'middlewares'
+import { validateSchema, isAdmin } from 'middlewares'
 import * as controller from './controller.suggestion'
-import { validateSchema } from 'middlewares'
 import * as validationSchemas from './validation.suggestion'
 const router = express.Router()
 

--- a/src/components/suggestion/validation.suggestion.ts
+++ b/src/components/suggestion/validation.suggestion.ts
@@ -1,0 +1,19 @@
+import Joi from 'joi'
+
+const addSuggestion = Joi.object({
+  iconName: Joi.string().required(),
+  type: Joi.string().valid('tags', 'category').required(),
+  suggestion: Joi.string().required()
+})
+
+const decide = Joi.object({
+  iconName: Joi.string().required(),
+  type: Joi.string().valid('tags', 'category').required(),
+  suggestions: Joi.array().items(Joi.string()),
+  status: Joi.string().valid('approved', 'rejected').required()
+})
+
+export {
+  addSuggestion,
+  decide
+}

--- a/src/documents/swagger.yaml
+++ b/src/documents/swagger.yaml
@@ -35,6 +35,10 @@ paths:
           description: 200 (Success)
           schema:
             $ref: '#/definitions/decideSuggestionsResponse'
+        "400":
+          description: 400 (Bad Request)
+          schema:
+            $ref: '#/definitions/validationError'
   /v2/suggestions/add:
     post:
       tags:
@@ -59,10 +63,12 @@ paths:
           description: 200 (Success)
           schema:
             $ref: '#/definitions/AddSuggestionsResponse'
-        "400":
-          description: The icon contains a blacklisted word
         "409":
           description: The icon is already exist or already suggested
+        "400":
+          description: 400 (Bad Request) or The icon contains a blacklisted word
+          schema:
+            $ref: '#/definitions/validationError'
   /v2/suggestions/getAll:
     post:
       tags:
@@ -108,6 +114,10 @@ paths:
           description: 200 (Success)
           schema:
             $ref: '#/definitions/getAllresponse'
+        "400":
+          description: 400 (Bad Request)
+          schema:
+            $ref: '#/definitions/validationError'
   /v2/icons/getString:
     post:
       tags:
@@ -128,6 +138,10 @@ paths:
           description: 200 (Success)
           schema:
             $ref: '#/definitions/getStringResponse'
+        "400":
+          description: 400 (Bad Request)
+          schema:
+            $ref: '#/definitions/validationError'
   /v2/icons/getFile:
     post:
       tags:
@@ -146,6 +160,10 @@ paths:
       responses:
         "200":
           description: 200 (Success) - a file will be downloaded if single icon, or a zip file if multiple icons
+        "400":
+          description: 400 (Bad Request)
+          schema:
+            $ref: '#/definitions/validationError'
   /v2/icons/getFont:
     post:
       tags:
@@ -164,6 +182,10 @@ paths:
       responses:
         "200":
           description: 200 (Success) - a zip folder will be downloaded
+        "400":
+          description: 400 (Bad Request)
+          schema:
+            $ref: '#/definitions/validationError'
 definitions:
   decideSuggestionsBody:
     required:
@@ -460,3 +482,8 @@ definitions:
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g
               fill="#ff0044" transform=" "><path
               d="M21.72,11.01l-4.01-7A1.96776,1.96776,0,0,0,15.98,3H8A1.96777,1.96777,0,0,0,6.27,4.01L4.74,6.68l-.8,1.39L2.26,11.01A2.0325,2.0325,0,0,0,2,12a2.00444,2.00444,0,0,0,.26.99l1.68,2.94.8,1.39,1.53,2.67A1.96777,1.96777,0,0,0,8,21h7.98a1.96776,1.96776,0,0,0,1.73-1.01l4.01-7a2.00444,2.00444,0,0,0,.26-.99A1.95565,1.95565,0,0,0,21.72,11.01Zm-4.38361,5.97351.00556-.00378-.0044.0075ZM20.28,12,17.345,16.97449c-.11835.00885-.23437.02551-.355.02551A4.99424,4.99424,0,0,1,12,12.09753V11.98A5.004,5.004,0,0,0,7,7a2.95969,2.95969,0,0,0-.31.03L7.89,5h8.26l4.14,7Z"/></g></svg>
+  validationError:
+    example: 
+      success: false
+      data: {}
+      message: 'The schema error will be shown here'

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,0 +1,1 @@
+export { default as validateSchema } from './validateSchema'

--- a/src/middlewares/validateSchema.ts
+++ b/src/middlewares/validateSchema.ts
@@ -1,0 +1,24 @@
+import { HTTPException } from 'helpers'
+import Joi from 'joi'
+import Express from 'express'
+
+const validateSchema = (schema: Joi.Schema, property: string, abortEarly:boolean = false) => {
+  return (req: Express.Request, res: Express.Response, next: Express.NextFunction) => {
+    if (!req[property]) {
+      req[property] = {} // for the case if called with empty body, to return the errors.
+    }
+    const { error } = schema.validate(req[property], {
+      abortEarly
+    })
+    if (error) {
+      const { details } = error
+      const errors = details.map((detail) => detail.message)
+      const err = new HTTPException(400, JSON.stringify(errors))
+      next(err)
+    } else {
+      next()
+    }
+  }
+}
+
+export default validateSchema


### PR DESCRIPTION
Hi, this PR introduces Joi validation layer, to throw a `400` code if the schema is not as we specified. 
The validation layer is only added to the `v2` APIs